### PR TITLE
Refactor 1pl methods

### DIFF
--- a/girth/__init__.py
+++ b/girth/__init__.py
@@ -1,8 +1,9 @@
-from .numba_functions import _compute_partial_integral, _array_LUT
+from .numba_functions import _array_LUT
 from .utils import (validate_estimation_options, irt_evaluation,
                     trim_response_set_and_counts,
                     convert_responses_to_kernel_sign,
-                    get_true_false_counts, mml_approx, create_beta_LUT,
+                    get_true_false_counts, mml_approx, 
+                    create_beta_LUT, _compute_partial_integral,
                     tag_missing_data, INVALID_RESPONSE)
 from .polytomous_utils import condition_polytomous_response
 from .synthetic import (create_correlated_abilities,

--- a/girth/__init__.py
+++ b/girth/__init__.py
@@ -1,4 +1,4 @@
-from .numba_functions import numba_expit, _compute_partial_integral, _array_LUT
+from .numba_functions import _compute_partial_integral, _array_LUT
 from .utils import (validate_estimation_options, irt_evaluation,
                     trim_response_set_and_counts,
                     convert_responses_to_kernel_sign,

--- a/girth/jml_methods.py
+++ b/girth/jml_methods.py
@@ -39,10 +39,9 @@ def _jml_abstract(dataset, _item_min_func,
             scalar = the_sign[:, ndx] * alphas
 
             def _theta_min(theta):
-                otpt = 1.0 / (1.0 + np.exp(scalar *
-                                           (theta - betas)))
+                otpt = np.exp(scalar * (theta - betas))
 
-                return -np.log(otpt).sum()
+                return np.log1p(otpt).sum()
 
             # Solves for the ability for each person
             thetas[ndx] = fminbound(_theta_min, -6, 6)
@@ -91,9 +90,8 @@ def rasch_jml(dataset, discrimination=1, options=None):
             scalar = alphas[0] * the_sign[ndx, :]
 
             def _beta_min(beta):
-                otpt = 1.0 / (1.0 + np.exp(scalar *
-                                           (thetas - beta)))
-                return -np.log(otpt).dot(counts)
+                otpt = np.exp(scalar * (thetas - beta))
+                return np.log1p(otpt).dot(counts)
 
             # Solves for the beta parameters
             betas[ndx] = fminbound(_beta_min, -6, 6)
@@ -135,9 +133,8 @@ def onepl_jml(dataset, options=None):
                 scalar = the_sign[ndx, :] * estimate
 
                 def _beta_min(beta):
-                    otpt = 1.0 / (1.0 + np.exp(scalar *
-                                               (thetas - beta)))
-                    return -np.log(otpt).dot(counts)
+                    otpt = np.exp(scalar * (thetas - beta))
+                    return np.log1p(otpt).dot(counts)
 
                 # Solves for the difficulty parameter for a given item at
                 # a specific discrimination parameter
@@ -180,9 +177,9 @@ def twopl_jml(dataset, options=None):
         # pylint: disable=cell-var-from-loop
         for ndx in range(n_items):
             def _alpha_beta_min(estimates):
-                otpt = 1.0 / (1.0 + np.exp((thetas - estimates[1]) *
-                                           the_sign[ndx, :] * estimates[0]))
-                return -np.log(otpt).dot(counts)
+                otpt = np.exp((thetas - estimates[1]) *
+                              the_sign[ndx, :] * estimates[0])
+                return np.log1p(otpt).dot(counts)
 
             # Solves jointly for parameters using numerical derivatives
             otpt = fmin_slsqp(_alpha_beta_min, (alphas[ndx], betas[ndx]),

--- a/girth/mml_eap_methods.py
+++ b/girth/mml_eap_methods.py
@@ -3,7 +3,6 @@ from scipy import stats
 
 from girth import (condition_polytomous_response, validate_estimation_options,
                    convert_responses_to_kernel_sign)
-from girth.numba_functions import numba_expit
 from girth.utils import create_beta_LUT
 from girth.latent_ability_distribution import LatentPDF
 from girth.polytomous_utils import (_graded_partial_integral, _solve_for_constants,

--- a/girth/mml_methods.py
+++ b/girth/mml_methods.py
@@ -1,10 +1,11 @@
 import numpy as np
 from scipy import integrate, stats
 from scipy.optimize import fminbound
+from scipy.special import expit
 
 from girth import (condition_polytomous_response, validate_estimation_options,
                    get_true_false_counts, convert_responses_to_kernel_sign)
-from girth.numba_functions import numba_expit, _compute_partial_integral
+from girth.numba_functions import _compute_partial_integral
 from girth.utils import _get_quadrature_points, create_beta_LUT
 from girth.latent_ability_distribution import LatentPDF
 from girth.polytomous_utils import (_graded_partial_integral, _solve_for_constants,
@@ -23,8 +24,8 @@ def _mml_abstract(difficulty, scalar, discrimination,
     for item_ndx in range(difficulty.shape[0]):
         # pylint: disable=cell-var-from-loop
         def min_zero_local(estimate):
-            temp = discrimination[item_ndx] * (estimate - theta)
-            kernel = numba_expit(temp)
+            temp = discrimination[item_ndx] * (theta - estimate)
+            kernel = expit(temp)
             integral = kernel.dot(distribution)
             
             return np.square(integral - scalar[item_ndx])

--- a/girth/numba_functions.py
+++ b/girth/numba_functions.py
@@ -1,43 +1,6 @@
 import numpy as np
 import numba as nb
 
-# Default to maximum 2 threads
-if nb.config.NUMBA_DEFAULT_NUM_THREADS > 1:  
-    nb.set_num_threads(2)
-
-
-@nb.njit(parallel=True)
-def _compute_partial_integral(theta, difficulty, discrimination, 
-                              the_sign, the_output): #pragma: no cover
-    """ Computes the partial integral for an IRT item
-
-    The return array is 2D with dimensions
-        (person x theta)
-
-    Args:
-        theta: (1d array) Quadrature locations
-        difficulty: (float) Item difficulty parameter
-        discrimination: (float) Item discrimination parameter
-        the_sign: (1d array) Sign of logistic function (-1, 0, 1)
-        the_output: (2d array) result of partial integral
-
-    Returns:
-        the_output: (2d array) is modified in-place
-
-    Notes:
-        DO NOT USE THIS WITHOUT NUMBA!!!
-        This will be slow without the compiler!
-    """ 
-    # Parallelize over people
-    for ndx1 in nb.prange(the_output.shape[0]):
-        local_sign = the_sign[ndx1] * discrimination
-
-        for ndx2 in range(the_output.shape[1]):
-            kernel = local_sign * (theta[ndx2] - difficulty)
-            the_output[ndx1, ndx2] = 1.0 / (1.0 + np.exp(kernel))
-    
-    return the_output
-
 
 @nb.njit()
 def _array_LUT(alpha, beta, theta, weight, output): #pragma: no cover

--- a/girth/numba_functions.py
+++ b/girth/numba_functions.py
@@ -6,22 +6,6 @@ if nb.config.NUMBA_DEFAULT_NUM_THREADS > 1:
     nb.set_num_threads(2)
 
 
-@nb.njit()
-def numba_expit(array): #pragma: no cover
-    """Computes the logistic function.
-
-    Logistic is defined as:
-        1 / (1 + exp(x))
-
-    Args:
-        array: Input array 'x' values
-    
-    Returns:
-        array: Output array of logistic values
-    """
-    return 1.0 / (1.0 + np.exp(array))
-
-
 @nb.njit(parallel=True)
 def _compute_partial_integral(theta, difficulty, discrimination, 
                               the_sign, the_output): #pragma: no cover

--- a/girth/polytomous_utils.py
+++ b/girth/polytomous_utils.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy import integrate
 from scipy.optimize import fminbound
+from scipy.special import expit
 
 from girth import INVALID_RESPONSE
-from girth.numba_functions import numba_expit
 
 
 def condition_polytomous_response(dataset, trim_ends=True, _reference=1.0):
@@ -87,10 +87,10 @@ def _graded_partial_integral(theta, betas, betas_roll,
                              discrimination, response_set,
                              invalid_response_mask):
     """Computes the partial integral for the graded response."""
-    temp1 = (betas[:, None] - theta) * discrimination[:, None]
-    temp2 = (betas_roll[:, None] - theta) * discrimination[:, None]
-    graded_prob = numba_expit(temp1) 
-    graded_prob -= numba_expit(temp2)
+    temp1 = (theta - betas[:, None]) * discrimination[:, None]
+    temp2 = (theta - betas_roll[:, None]) * discrimination[:, None]
+    graded_prob = expit(temp1) 
+    graded_prob -= expit(temp2)
 
     # Set all the responses and fix afterward
     temp_output = graded_prob[response_set, :]

--- a/girth/utils.py
+++ b/girth/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import interpolate
 from scipy.stats import norm as gaussian
-from scipy.special import roots_legendre
+from scipy.special import roots_legendre, expit
 
 from girth import _array_LUT
 
@@ -148,6 +148,32 @@ def mml_approx(dataset, discrimination=1, scalar=None):
 
     return (np.sqrt(1 + discrimination**2 / 3) *
             scalar / discrimination)
+
+
+def _compute_partial_integral(theta, difficulty, discrimination, 
+                              responses, invalid_response_mask):
+    """ Computes the partial integral for an IRT item
+
+    The return array is 2D with dimensions
+        (person x theta)
+
+    Args:
+        theta: (1d array) Quadrature locations
+        difficulty: (float) Item difficulty parameter
+        discrimination: (float) Item discrimination parameter
+        responses: (1d array) Correct (1) or Incorrect (0)
+        invalid_response_mask: (1d array) mask where data is missing
+
+    Returns:
+        the_output: (2d array) is modified in-place
+    """                               
+    probability = expit(np.outer([-1, 1], 
+                        discrimination * (theta - difficulty)))
+    
+    # Mask out missing responses
+    temp_output = probability[responses, :]
+    temp_output[invalid_response_mask] = 1
+    return temp_output
 
 
 def convert_responses_to_kernel_sign(responses):

--- a/testing/test_ability_methods.py
+++ b/testing/test_ability_methods.py
@@ -7,7 +7,8 @@ from girth.ability_methods import _ability_eap_abstract
 from girth import (ability_eap, ability_map, 
                    ability_mle)
 
-from girth import create_synthetic_irt_dichotomous                   
+from girth import create_synthetic_irt_dichotomous
+from girth.utils import INVALID_RESPONSE                
 
 
 def _rmse(expected, result):
@@ -45,9 +46,8 @@ class TestAbilityEstimates(unittest.TestCase):
         # Add missing values
         dataset = create_synthetic_irt_dichotomous(self.difficulty, self.discrimination,
                                                    self.expected_theta, seed=312)
-        dataset = dataset.astype('float')
         mask = np.random.rand(*dataset.shape) < 0.1
-        dataset[mask] = np.nan
+        dataset[mask] = INVALID_RESPONSE
         self.set_four = dataset
 
         # Regression Test

--- a/testing/test_numba_functions.py
+++ b/testing/test_numba_functions.py
@@ -4,7 +4,7 @@ import numpy as np
 import numba as nb
 
 from girth.utils import _get_quadrature_points
-from girth.numba_functions import _compute_partial_integral, _array_LUT
+from girth.numba_functions import _array_LUT
 
 # These don't register as covered tests in nose but
 # The tests do run

--- a/testing/test_numba_functions.py
+++ b/testing/test_numba_functions.py
@@ -4,25 +4,15 @@ import numpy as np
 import numba as nb
 
 from girth.utils import _get_quadrature_points
-from girth.numba_functions import numba_expit, _compute_partial_integral, _array_LUT
+from girth.numba_functions import _compute_partial_integral, _array_LUT
 
 # These don't register as covered tests in nose but
 # The tests do run
 
 class NumbaTests(unittest.TestCase):
 
-
-    def test_numba_expit(self):
-        """Test the numba function for expit function."""
-        np.random.seed(342342)
-        output = np.random.randn(300, 300) * 2
-
-        numba_result = numba_expit(output)
-        numpy_result = 1.0 / (1.0 + np.exp(output))
-
-        np.testing.assert_allclose(numba_result, numpy_result, 
-        atol=1e-4, rtol=1e-5)
-
+    # Testing numba functions
+    
     def test_array_LUT(self):
         """Test the creation of the array look up table."""
         alpha = np.linspace(.2, 4, 500)

--- a/testing/test_utils.py
+++ b/testing/test_utils.py
@@ -11,8 +11,8 @@ from girth import (create_synthetic_irt_dichotomous,
                    validate_estimation_options, condition_polytomous_response,
                    get_true_false_counts, mml_approx)
 from girth.utils import (_get_quadrature_points, default_options, 
-                         create_beta_LUT, tag_missing_data, INVALID_RESPONSE)
-from girth.numba_functions import _compute_partial_integral
+                        create_beta_LUT, tag_missing_data, INVALID_RESPONSE,
+                        _compute_partial_integral)
 from girth.polytomous_utils import (_graded_partial_integral, _solve_for_constants,
                                     _solve_integral_equations, _credit_partial_integral,
                                     _unfold_partial_integral)
@@ -69,15 +69,15 @@ class TestUtilitiesMethods(unittest.TestCase):
 
         discrimination = 1.32
         difficulty = .67
-        the_sign = (-1)**np.random.randint(low=0, high=2, size=(1, 10))
+        response = np.random.randint(low=0, high=2, size=(1, 10))
 
         quad_points, _ = _get_quadrature_points(61, -6, 6)
-        the_output = np.zeros((the_sign.shape[1], quad_points.size))        
-        value = _compute_partial_integral(quad_points, difficulty, 
-                                          discrimination, the_sign[0],
-                                          the_output)
 
-        discrrm = discrimination * the_sign
+        value = _compute_partial_integral(quad_points, difficulty, 
+                                          discrimination, response[0],
+                                          np.zeros_like(response, dtype='bool')[0])
+
+        discrrm = discrimination * np.power(-1, response)
         expected = 1.0 / (1 + np.exp(np.outer(discrrm, (quad_points - difficulty))))
         np.testing.assert_allclose(value, expected)
 


### PR DESCRIPTION
Continued work on #81, no change in SLOC, but simplified partial integral code used in Rasch/1PL/Ability Methods. Can potentially remove function ```convert_responses_to_kernel_sign``` now. 