### PR TITLE
Merge synthetic data creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ of time
 ```python
 import numpy as np
 
-from girth import create_synthetic_mirt_dichotomous
+from girth import create_synthetic_irt_dichotomous
 from girth import multidimensional_twopl_mml
 
 # Create Synthetic Data
@@ -151,7 +151,7 @@ discrimination = np.random.uniform(-2, 2, (20, 2))
 thetas = np.random.randn(2, 1000)
 difficulty = np.linspace(-1.5, 1, 20)
 
-syn_data = create_synthetic_mirt_dichotomous(difficulty, discrimination, thetas)
+syn_data = create_synthetic_irt_dichotomous(difficulty, discrimination, thetas)
 
 # Solve for parameters
 estimates = multidimensional_twopl_mml(syn_data, 2, {'quadrature_n': 21})
@@ -217,7 +217,7 @@ discrimination = np.random.uniform(-2, 2, (20, 2))
 thetas = np.random.randn(2, 1000)
 difficulty = np.linspace(-1.5, 1, 20)
 
-syn_data = girth.create_synthetic_mirt_dichotomous(difficulty, discrimination, thetas)
+syn_data = girth.create_synthetic_irt_dichotomous(difficulty, discrimination, thetas)
 
 polychoric_corr = gcm.polychoric_correlation(syn_data, start_val=0, stop_val=1)
 

--- a/src/test/test_multidimensional_ability_methods.py
+++ b/src/test/test_multidimensional_ability_methods.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from girth import multidimensional_ability_eap, multidimensional_ability_map
-from girth.synthetic import create_synthetic_mirt_dichotomous, create_synthetic_irt_polytomous
+from girth.synthetic import create_synthetic_irt_dichotomous, create_synthetic_irt_polytomous
 
 
 class TestMultidimensionalMethods(unittest.TestCase):
@@ -28,8 +28,8 @@ class TestMultidimensionalMethods(unittest.TestCase):
         difficulty = np.linspace(-1.5, 1.5, 10)
         thetas = rng.standard_normal((3, 250))
 
-        syn_data = create_synthetic_mirt_dichotomous(difficulty, discrimination, 
-                                                     thetas, seed=rng)
+        syn_data = create_synthetic_irt_dichotomous(difficulty, discrimination, 
+                                                    thetas, seed=rng)
         
         abilities_eap = multidimensional_ability_eap(syn_data, difficulty, 
                                                      discrimination, {'quadrature_n': 21})

--- a/src/test/test_multidimensional_mml.py
+++ b/src/test/test_multidimensional_mml.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from girth import create_synthetic_mirt_dichotomous, create_synthetic_irt_polytomous
+from girth import create_synthetic_irt_dichotomous, create_synthetic_irt_polytomous
 from girth import multidimensional_grm_mml, multidimensional_twopl_mml
 from girth import initial_guess_md
 
@@ -21,7 +21,7 @@ class TestMultiDimensionalIRT(unittest.TestCase):
         discrimination[-1, 0] *= np.sign(discrimination[-1, 0])
         discrimination[-2, -1] *= np.sign(discrimination[-2, -1])
         thetas = rng.standard_normal((2, 1000))
-        syn_data = create_synthetic_mirt_dichotomous(difficulty, 
+        syn_data = create_synthetic_irt_dichotomous(difficulty, 
                                                      discrimination, 
                                                      thetas, seed=rng)
         
@@ -85,7 +85,7 @@ class TestMultiDimensionalIRT(unittest.TestCase):
         discrimination[-1, 0] *= np.sign(discrimination[-1, 0])
         discrimination[-2, -1] *= np.sign(discrimination[-2, -1])
         thetas = rng.standard_normal((2, 2000))
-        syn_data = create_synthetic_mirt_dichotomous(difficulty, 
+        syn_data = create_synthetic_irt_dichotomous(difficulty, 
                                                      discrimination, 
                                                      thetas, seed=rng)
 

--- a/src/test/test_synthetic.py
+++ b/src/test/test_synthetic.py
@@ -2,9 +2,7 @@ import unittest
 
 import numpy as np
 
-from girth import create_synthetic_irt_dichotomous
-from girth import create_synthetic_mirt_dichotomous
-from girth import create_synthetic_irt_polytomous
+from girth import create_synthetic_irt_dichotomous, create_synthetic_irt_polytomous
 
 from girth.synthetic import (_my_digitize, _credit_func, 
                              _graded_func, _unfold_func,
@@ -48,33 +46,24 @@ class TestSynthetic(unittest.TestCase):
         discrimination = rng.standard_normal((n_items, n_factors))
         difficulty = np.linspace(-5, 5, n_items)
         thetas = rng.standard_normal((n_factors, n_people))
-        value = create_synthetic_mirt_dichotomous(difficulty, discrimination,
-                                                  thetas, seed=rng)
+        value = create_synthetic_irt_dichotomous(difficulty, discrimination,
+                                                 thetas, seed=rng)
 
         np.testing.assert_array_equal(expected, value)
 
-    def test_synthetic_mirt_creation_single(self):
-        """Testing the creation of synthetic data, common discrimination."""
-        rng = np.random.default_rng(3847520938201012)
-
-        # Regression test
-        expected = np.array([
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 1, 1, 1, 0],
-            [0, 0, 1, 1, 1, 0],
-            [1, 1, 1, 1, 1, 0]
-        ])
-
+    def test_mirt_fails(self):
+        """Testing that multidimensional fails when discrimination is too large."""
+        
         n_factors = 3
         n_items = 5
         n_people = 6
-        discrimination = rng.standard_normal((1, n_factors))
+        discrimination = np.random.randn(*(n_items, n_factors, 3))
         difficulty = np.linspace(-5, 5, n_items)
-        thetas = rng.standard_normal((n_factors, n_people))
-        value = create_synthetic_mirt_dichotomous(difficulty, discrimination,
-                                                  thetas, seed=rng)
-        np.testing.assert_array_equal(expected, value)
+        thetas = np.random.randn(*(n_factors, n_people))
+
+        with self.assertRaises(AssertionError):
+            value = create_synthetic_irt_dichotomous(difficulty, discrimination,
+                                                     thetas)
 
 
 class TestPolytomousSynthetic(unittest.TestCase):


### PR DESCRIPTION
The ```create_synthetic_mirt_dichotomous``` has been removed and the ```create_synthetic_irt_dichotomous``` now supports univariate and multivariate synthetic data creation. There are still two distinct dichotomous and polytomous functions and this is on purpose as users need to explicitly call the synthetic data they want.